### PR TITLE
Add support  for `arrow=59`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@
           "run": "cargo check -p marrow --features arrow2-0-16"
         },
         {
+          "name": "Check arrow-59",
+          "run": "cargo check -p marrow --features arrow-59"
+        },
+        {
           "name": "Check arrow-58",
           "run": "cargo check -p marrow --features arrow-58"
         },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,10 @@
           "run": "cargo check -p marrow --features arrow2-0-16"
         },
         {
+          "name": "Check arrow-59",
+          "run": "cargo check -p marrow --features arrow-59"
+        },
+        {
           "name": "Check arrow-58",
           "run": "cargo check -p marrow --features arrow-58"
         },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "marrow"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "arrow-array 37.0.0",
  "arrow-array 38.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,14 +332,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "b02ccba2e977a3aabb4384036109ca32f552399a2bc0588f925f91ed073ce70c"
 dependencies = [
  "ahash",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
  "chrono",
  "half",
  "hashbrown 0.16.1",
@@ -348,14 +348,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
 dependencies = [
  "ahash",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-buffer 57.3.1",
+ "arrow-data 57.3.1",
+ "arrow-schema 57.3.1",
  "chrono",
  "half",
  "hashbrown 0.16.1",
@@ -366,17 +366,35 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.0.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash",
- "arrow-buffer 58.0.0",
- "arrow-data 58.0.0",
- "arrow-schema 58.0.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
+dependencies = [
+ "ahash",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -584,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "a90f8bece6a9ee316a699fbbfde368a206676a1206ce89b50f07937648e76c3c"
 dependencies = [
  "bytes",
  "half",
@@ -595,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
 dependencies = [
  "bytes",
  "half",
@@ -607,9 +625,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.0.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
 dependencies = [
  "bytes",
  "half",
@@ -847,24 +877,24 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "78468c813909465dd0f858950c8a0614eb63608134acf95c602ec21381258b28"
 dependencies = [
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-buffer 56.2.1",
+ "arrow-schema 56.2.1",
  "half",
  "num",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
 dependencies = [
- "arrow-buffer 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-buffer 57.3.1",
+ "arrow-schema 57.3.1",
  "half",
  "num-integer",
  "num-traits",
@@ -872,12 +902,25 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.0.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
- "arrow-buffer 58.0.0",
- "arrow-schema 58.0.0",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
+dependencies = [
+ "arrow-buffer 59.0.0",
+ "arrow-schema 59.0.0",
  "half",
  "num-integer",
  "num-traits",
@@ -1056,18 +1099,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "5a0d5eb3fe25337ff83e8333a08379bdd1540b0961b1c888f6e505d971c198e1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
 dependencies = [
  "serde",
  "serde_core",
@@ -1075,9 +1118,19 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.0.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
 dependencies = [
  "serde",
  "serde_core",
@@ -1125,15 +1178,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -1163,9 +1216,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1179,9 +1232,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -1228,15 +1281,15 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1249,6 +1302,30 @@ name = "foreign_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1b05cbd864bcaecbd3455d6d967862d446e4ebfc3c2e5e5b9841e53cba6673"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -1319,6 +1396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,25 +1427,26 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1372,9 +1456,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "marrow"
@@ -1399,9 +1483,10 @@ dependencies = [
  "arrow-array 53.4.0",
  "arrow-array 54.3.1",
  "arrow-array 55.2.0",
- "arrow-array 56.2.0",
- "arrow-array 57.3.0",
- "arrow-array 58.0.0",
+ "arrow-array 56.2.1",
+ "arrow-array 57.3.1",
+ "arrow-array 58.3.0",
+ "arrow-array 59.0.0",
  "arrow-buffer 37.0.0",
  "arrow-buffer 38.0.0",
  "arrow-buffer 39.0.0",
@@ -1421,9 +1506,10 @@ dependencies = [
  "arrow-buffer 53.4.1",
  "arrow-buffer 54.3.1",
  "arrow-buffer 55.2.0",
- "arrow-buffer 56.2.0",
- "arrow-buffer 57.3.0",
- "arrow-buffer 58.0.0",
+ "arrow-buffer 56.2.1",
+ "arrow-buffer 57.3.1",
+ "arrow-buffer 58.3.0",
+ "arrow-buffer 59.0.0",
  "arrow-data 37.0.0",
  "arrow-data 38.0.0",
  "arrow-data 39.0.0",
@@ -1443,9 +1529,10 @@ dependencies = [
  "arrow-data 53.4.1",
  "arrow-data 54.3.1",
  "arrow-data 55.2.0",
- "arrow-data 56.2.0",
- "arrow-data 57.3.0",
- "arrow-data 58.0.0",
+ "arrow-data 56.2.1",
+ "arrow-data 57.3.1",
+ "arrow-data 58.3.0",
+ "arrow-data 59.0.0",
  "arrow-schema 37.0.0",
  "arrow-schema 38.0.0",
  "arrow-schema 39.0.0",
@@ -1465,9 +1552,10 @@ dependencies = [
  "arrow-schema 53.4.1",
  "arrow-schema 54.3.1",
  "arrow-schema 55.2.0",
- "arrow-schema 56.2.0",
- "arrow-schema 57.3.0",
- "arrow-schema 58.0.0",
+ "arrow-schema 56.2.1",
+ "arrow-schema 57.3.1",
+ "arrow-schema 58.3.0",
+ "arrow-schema 59.0.0",
  "arrow2 0.16.0",
  "arrow2 0.17.4",
  "bytemuck",
@@ -1477,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num"
@@ -1557,9 +1645,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -1572,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1602,9 +1696,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1638,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1651,15 +1745,21 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -1695,9 +1795,10 @@ dependencies = [
  "arrow-array 53.4.0",
  "arrow-array 54.3.1",
  "arrow-array 55.2.0",
- "arrow-array 56.2.0",
- "arrow-array 57.3.0",
- "arrow-array 58.0.0",
+ "arrow-array 56.2.1",
+ "arrow-array 57.3.1",
+ "arrow-array 58.3.0",
+ "arrow-array 59.0.0",
  "arrow-schema 37.0.0",
  "arrow-schema 38.0.0",
  "arrow-schema 39.0.0",
@@ -1717,9 +1818,10 @@ dependencies = [
  "arrow-schema 53.4.1",
  "arrow-schema 54.3.1",
  "arrow-schema 55.2.0",
- "arrow-schema 56.2.0",
- "arrow-schema 57.3.0",
- "arrow-schema 58.0.0",
+ "arrow-schema 56.2.1",
+ "arrow-schema 57.3.1",
+ "arrow-schema 58.3.0",
+ "arrow-schema 59.0.0",
  "chrono",
  "half",
  "marrow",
@@ -1755,18 +1857,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1777,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1787,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1800,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -1868,24 +1970,24 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.2.7
+
+- Add `arrow=57` support
+
 ## 0.2.6
 
 - Add `arrow=58` support

--- a/Changes.md
+++ b/Changes.md
@@ -2,7 +2,7 @@
 
 ## 0.2.7
 
-- Add `arrow=57` support
+- Add `arrow=59` support
 
 ## 0.2.6
 

--- a/marrow/Cargo.toml
+++ b/marrow/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "marrow"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Christopher Prohm <mail@cprohm.de>"]
 description  = "Minimalist Arrow interop"
 readme = "../Readme.md"

--- a/marrow/Cargo.toml
+++ b/marrow/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.70.0"
 
 [package.metadata.docs.rs]
 # arrow-version:replace: features = ["arrow2-0-17", "arrow-{version}", "serde"]
-features = ["arrow2-0-17", "arrow-58", "serde"]
+features = ["arrow2-0-17", "arrow-59", "serde"]
 
 [features]
 default = []
@@ -23,6 +23,7 @@ serde = ["dep:serde"]
 
 # support for different arrow versions
 # arrow-version:insert: arrow-{version} = ["dep:arrow-array-{version}", "dep:arrow-schema-{version}", "dep:arrow-data-{version}", "dep:arrow-buffer-{version}"]
+arrow-59 = ["dep:arrow-array-59", "dep:arrow-schema-59", "dep:arrow-data-59", "dep:arrow-buffer-59"]
 arrow-58 = ["dep:arrow-array-58", "dep:arrow-schema-58", "dep:arrow-data-58", "dep:arrow-buffer-58"]
 arrow-57 = ["dep:arrow-array-57", "dep:arrow-schema-57", "dep:arrow-data-57", "dep:arrow-buffer-57"]
 arrow-56 = ["dep:arrow-array-56", "dep:arrow-schema-56", "dep:arrow-data-56", "dep:arrow-buffer-56"]
@@ -57,6 +58,7 @@ half = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"], optional = true }
 
 # arrow-version:insert: arrow-array-{version} = {{ package = "arrow-array", version = "{version}", optional = true, default-features = false }}
+arrow-array-59 = { package = "arrow-array", version = "59", optional = true, default-features = false }
 arrow-array-58 = { package = "arrow-array", version = "58", optional = true, default-features = false }
 arrow-array-57 = { package = "arrow-array", version = "57", optional = true, default-features = false }
 arrow-array-56 = { package = "arrow-array", version = "56", optional = true, default-features = false }
@@ -81,6 +83,7 @@ arrow-array-38 = { package = "arrow-array", version = "38", optional = true, def
 arrow-array-37 = { package = "arrow-array", version = "37", optional = true, default-features = false }
 
 # arrow-version:insert: arrow-buffer-{version} = {{ package = "arrow-buffer", version = "{version}", optional = true, default-features = false }}
+arrow-buffer-59 = { package = "arrow-buffer", version = "59", optional = true, default-features = false }
 arrow-buffer-58 = { package = "arrow-buffer", version = "58", optional = true, default-features = false }
 arrow-buffer-57 = { package = "arrow-buffer", version = "57", optional = true, default-features = false }
 arrow-buffer-56 = { package = "arrow-buffer", version = "56", optional = true, default-features = false }
@@ -105,6 +108,7 @@ arrow-buffer-38 = { package = "arrow-buffer", version = "38", optional = true, d
 arrow-buffer-37 = { package = "arrow-buffer", version = "37", optional = true, default-features = false }
 
 # arrow-version:insert: arrow-data-{version} = {{ package = "arrow-data", version="{version}", optional = true, default-features = false }}
+arrow-data-59 = { package = "arrow-data", version="59", optional = true, default-features = false }
 arrow-data-58 = { package = "arrow-data", version="58", optional = true, default-features = false }
 arrow-data-57 = { package = "arrow-data", version="57", optional = true, default-features = false }
 arrow-data-56 = { package = "arrow-data", version="56", optional = true, default-features = false }
@@ -129,6 +133,7 @@ arrow-data-38 = { package = "arrow-data", version="38", optional = true, default
 arrow-data-37 = { package = "arrow-data", version="37", optional = true, default-features = false }
 
 # arrow-version:insert: arrow-schema-{version} = {{ package = "arrow-schema", version = "{version}", optional = true, default-features = false }}
+arrow-schema-59 = { package = "arrow-schema", version = "59", optional = true, default-features = false }
 arrow-schema-58 = { package = "arrow-schema", version = "58", optional = true, default-features = false }
 arrow-schema-57 = { package = "arrow-schema", version = "57", optional = true, default-features = false }
 arrow-schema-56 = { package = "arrow-schema", version = "56", optional = true, default-features = false }

--- a/marrow/src/impl_arrow/mod.rs
+++ b/marrow/src/impl_arrow/mod.rs
@@ -2,6 +2,11 @@
 #![cfg_attr(any(), rustfmt::skip)]
 
 // arrow-version:insert: #[cfg(feature = "arrow-{version}")]{\n}mod arrow_{version} {{{\n}    use {{arrow_array_{version} as arrow_array, arrow_buffer_{version} as arrow_buffer, arrow_data_{version} as arrow_data, arrow_schema_{version} as arrow_schema}};{\n}    include!("impl_api_53.rs");{\n}}}
+#[cfg(feature = "arrow-59")]
+mod arrow_59 {
+    use {arrow_array_59 as arrow_array, arrow_buffer_59 as arrow_buffer, arrow_data_59 as arrow_data, arrow_schema_59 as arrow_schema};
+    include!("impl_api_53.rs");
+}
 #[cfg(feature = "arrow-58")]
 mod arrow_58 {
     use {arrow_array_58 as arrow_array, arrow_buffer_58 as arrow_buffer, arrow_data_58 as arrow_data, arrow_schema_58 as arrow_schema};

--- a/marrow/src/lib.rs
+++ b/marrow/src/lib.rs
@@ -99,6 +99,7 @@
 //! | Feature       | Arrow Version |
 //! |---------------|---------------|
 // arrow-version:insert: //! | `arrow-{version}`    | `arrow={version}`    |
+//! | `arrow-59`    | `arrow=59`    |
 //! | `arrow-58`    | `arrow=58`    |
 //! | `arrow-56`    | `arrow=56`    |
 //! | `arrow-55`    | `arrow=55`    |

--- a/test_with_arrow/Cargo.toml
+++ b/test_with_arrow/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [features]
 
 # arrow-version:insert: arrow-{version} = ["marrow/arrow-{version}", "dep:arrow-array-{version}", "dep:arrow-schema-{version}"]
+arrow-59 = ["marrow/arrow-59", "dep:arrow-array-59", "dep:arrow-schema-59"]
 arrow-58 = ["marrow/arrow-58", "dep:arrow-array-58", "dep:arrow-schema-58"]
 arrow-57 = ["marrow/arrow-57", "dep:arrow-array-57", "dep:arrow-schema-57"]
 arrow-56 = ["marrow/arrow-56", "dep:arrow-array-56", "dep:arrow-schema-56"]
@@ -40,6 +41,7 @@ serde_json = "1"
 chrono = { version = "0.4", default-features = false }
 
 # arrow-version:insert: arrow-array-{version} = {{ package = "arrow-array", version="{version}", optional = true, default-features = false }}
+arrow-array-59 = { package = "arrow-array", version="59", optional = true, default-features = false }
 arrow-array-58 = { package = "arrow-array", version="58", optional = true, default-features = false }
 arrow-array-57 = { package = "arrow-array", version="57", optional = true, default-features = false }
 arrow-array-56 = { package = "arrow-array", version="56", optional = true, default-features = false }
@@ -64,6 +66,7 @@ arrow-array-38 = { package = "arrow-array", version="38", optional = true, defau
 arrow-array-37 = { package = "arrow-array", version="37", optional = true, default-features = false }
 
 # arrow-version:insert: arrow-schema-{version} = {{ package = "arrow-schema", version = "{version}", optional = true, default-features = false, features = ["serde"] }}
+arrow-schema-59 = { package = "arrow-schema", version = "59", optional = true, default-features = false, features = ["serde"] }
 arrow-schema-58 = { package = "arrow-schema", version = "58", optional = true, default-features = false, features = ["serde"] }
 arrow-schema-57 = { package = "arrow-schema", version = "57", optional = true, default-features = false, features = ["serde"] }
 arrow-schema-56 = { package = "arrow-schema", version = "56", optional = true, default-features = false, features = ["serde"] }

--- a/test_with_arrow/src/lib.rs
+++ b/test_with_arrow/src/lib.rs
@@ -17,6 +17,7 @@ macro_rules! define_test_module {
 }
 
 // arrow-version:insert: define_test_module!("arrow-{version}", arrow_{version}, arrow_array_{version}, arrow_schema_{version}, utils, arrays, data_types,struct_arrays, fixed_size_binary_arrays, intervals, union_arrays, views);
+define_test_module!("arrow-59", arrow_59, arrow_array_59, arrow_schema_59, utils, arrays, data_types,struct_arrays, fixed_size_binary_arrays, intervals, union_arrays, views);
 define_test_module!("arrow-58", arrow_58, arrow_array_58, arrow_schema_58, utils, arrays, data_types,struct_arrays, fixed_size_binary_arrays, intervals, union_arrays, views);
 define_test_module!("arrow-56", arrow_56, arrow_array_56, arrow_schema_56, utils, arrays, data_types,struct_arrays, fixed_size_binary_arrays, intervals, union_arrays, views);
 define_test_module!("arrow-55", arrow_55, arrow_array_55, arrow_schema_55, utils, arrays, data_types,struct_arrays, fixed_size_binary_arrays, intervals, union_arrays, views);

--- a/test_with_arrow/src/tests/utils.rs
+++ b/test_with_arrow/src/tests/utils.rs
@@ -34,9 +34,9 @@ impl<E: std::error::Error> From<E> for PanicOnErrorError {
 pub type PanicOnError<T, E = PanicOnErrorError> = std::result::Result<T, E>;
 
 pub fn as_array_ref<A: arrow_array::Array + 'static>(
-    values: impl Into<A>,
+    values: impl TryInto<A, Error = impl std::fmt::Debug>,
 ) -> arrow_array::ArrayRef {
-    Arc::new(values.into()) as arrow_array::ArrayRef
+    Arc::new(values.try_into().unwrap()) as arrow_array::ArrayRef
 }
 
 pub fn assert_arrays_eq(

--- a/x.py
+++ b/x.py
@@ -11,6 +11,7 @@ arg = lambda *a, **kw: __effect(lambda d: d.setdefault("@arg", []).append((a, kw
 
 all_arrow_features = [
     # arrow-version:insert:     "arrow-{version}",
+    "arrow-59",
     "arrow-58",
     "arrow-57",
     "arrow-56",


### PR DESCRIPTION
- Add `arrow=59` support
- Use `TryInto` in test code, as `arrow=59` dropped support for infaillable conversions for `FixedSizeBinaryArray`
- Update Changelog